### PR TITLE
사용자 개인정보 관련 에러메시지 추가

### DIFF
--- a/src/main/java/com/y/java_board/controller/UserController.java
+++ b/src/main/java/com/y/java_board/controller/UserController.java
@@ -70,6 +70,7 @@ public class UserController {
             commentsByPage(model, commentPage, userInfoSession.getNickname());
         } catch (IOException e) {
             model.put("profileImage", "");
+            System.err.println(e.getMessage());
         }
         return "user/info";
     }


### PR DESCRIPTION
Azure에 배포해보니 사용자 개인정보 관련 부분을 누르니 500 메시지가 뜨고, 서버에선 특정 로그가 없었다. 정확한 문제를 확인하기 위해서 err message를 추가한다. 